### PR TITLE
Treat null-terminator as optional for string properties.

### DIFF
--- a/src/ewmh.rs
+++ b/src/ewmh.rs
@@ -1128,7 +1128,9 @@ define!(reply GetWmNameReply for xcb_ewmh_get_utf8_strings_reply_t with xcb_ewmh
 
 impl GetWmNameReply {
 	pub fn string(&self) -> &str {
-		utf8::into(self.0.strings, self.0.strings_len)[0]
+		utf8::into(self.0.strings, self.0.strings_len)
+			.get(0)
+			.unwrap_or(&"")
 	}
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -281,9 +281,20 @@ pub mod utf8 {
 	use libc::c_char;
 
 	pub fn into<'a>(data: *const c_char, length: u32) -> Vec<&'a str> {
+		if length == 0 {
+			return Vec::new();
+		}
 		unsafe {
-			str::from_utf8_unchecked(slice::from_raw_parts(data as *mut u8, length as usize - 1))
-				.split('\0').collect()
+			let mut strs = str::from_utf8_unchecked(slice::from_raw_parts(data as *mut u8, length as usize))
+				.split('\0')
+				.collect::<Vec<_>>();
+			// data is sometimes null-terminated and sometimes not. If there is
+			// a null terminator, then our call to .split() will result in an
+			// extra empty-string element at the end.
+			if let Some(&"") = strs.last() {
+				strs.pop();
+			}
+			strs
 		}
 	}
 


### PR DESCRIPTION
It seems many popular applications (Spotify, Chorome, urxvt) don't null
terminate `WM_NAME`. Check if the final byte of strings is null and adjust
the length accordingly.

This will affect properties like `_NET_WM_DESKTOP_NAMES` too which are
arrays of strings. In the one WM I looked at (QTile), it didn't
null-terminate the final element in the array either (i.e. it was
`'desktop1\0desktop2\0desktop3'`), so I think being more permissive about
what we accept is a good thing.