### PR TITLE
Bump xcb dep to 0.8, bump xcb-util version to 0.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "xcb-util"
-version = "0.1.8"
+version = "0.2.0"
 
 authors = ["meh. <meh@schizofreni.co>"]
 license = "MIT"
@@ -11,7 +11,7 @@ keywords    = ["x11", "xcb"]
 
 [dependencies]
 libc = "0.2"
-xcb  = "0.7"
+xcb  = "0.8"
 
 [features]
 static = []


### PR DESCRIPTION
As some types (at least `xcb::Connection` and `xcb::GenericError`) are used
in the public API of xcb-util, this is a breaking change for xcb-util
too.
