### PR TITLE
icccm: fix the ordering of instance and class in set_wm_class

### DIFF
--- a/src/icccm.rs
+++ b/src/icccm.rs
@@ -202,7 +202,7 @@ impl GetWmClassReply {
 }
 
 pub fn set_wm_class<A: AsRef<str>, B: AsRef<str>>(c: &xcb::Connection, window: xcb::Window, class: A, instance: B) -> xcb::VoidCookie {
-	let value = utf8::from(vec![class.as_ref(), instance.as_ref()]);
+	let value = utf8::from(vec![instance.as_ref(), class.as_ref()]);
 
 	void!(unchecked -> c,
 		xcb_icccm_set_wm_class(c.get_raw_conn(), window,


### PR DESCRIPTION
Before, this one would output `class: instance, instance: class`
```rust
icccm::set_wm_class(&conn, window, "class", "instance");
let cr = icccm::get_wm_class(&conn, window).get_reply().unwrap();
println!("class: {}, instance: {}", cr.class(), cr.instance());
```
Also when I used `xprop` the ordering of class and instance did not seem to match that of other apps