### PR TITLE
update to xcb 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords    = ["x11", "xcb"]
 
 [dependencies]
 libc = "0.2"
-xcb  = "0.9"
+xcb  = "0.10"
 
 [features]
 static = []

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -90,7 +90,7 @@ pub fn create_font_cursor(c: &xcb::Connection, glyph: u16) -> xcb::Cursor {
 	cursor
 }
 
-pub fn create_font_cursor_checked(c: &xcb::Connection, glyph: u16) -> Result<xcb::Cursor, xcb::GenericError> {
+pub fn create_font_cursor_checked(c: &xcb::Connection, glyph: u16) -> Result<xcb::Cursor, xcb::ReplyError> {
 	let font = c.generate_id();
 	xcb::open_font_checked(c, font, "cursor").request_check()?;
 

--- a/src/ewmh.rs
+++ b/src/ewmh.rs
@@ -233,7 +233,7 @@ unsafe impl<'a> Send for Connection { }
 unsafe impl<'a> Sync for Connection { }
 
 impl Connection {
-	pub fn connect(xcb: xcb::Connection) -> Result<Connection, (xcb::GenericError, xcb::Connection)> {
+	pub fn connect(xcb: xcb::Connection) -> Result<Connection, (xcb::ReplyError, xcb::Connection)> {
 		unsafe {
 			let mut ewmh = mem::zeroed();
 			let mut err: *mut xcb_generic_error_t = ptr::null_mut();
@@ -248,7 +248,7 @@ impl Connection {
 				})
 			}
 			else {
-				Err((xcb::GenericError { ptr: err }, xcb))
+				Err((xcb::ReplyError::GenericError(xcb::GenericError { ptr: err }), xcb))
 			}
 		}
 	}

--- a/src/icccm.rs
+++ b/src/icccm.rs
@@ -656,11 +656,11 @@ pub struct GetWmStateCookie<'a>(xcb::GetPropertyCookie<'a>);
 pub struct GetWmStateReply(xcb::GetPropertyReply);
 
 impl<'a> GetWmStateCookie<'a> {
-	pub fn get_reply(self) -> Result<GetWmStateReply, xcb::GenericError> {
+	pub fn get_reply(self) -> Result<GetWmStateReply, xcb::ReplyError> {
 		let reply = self.0.get_reply()?;
 		
 		if reply.type_() == xcb::ATOM_NONE {
-			Err(xcb::GenericError { ptr: ptr::null_mut() })
+			Err(xcb::ReplyError::GenericError(xcb::GenericError { ptr: ptr::null_mut() }))
 		}
 		else {
 			Ok(GetWmStateReply(reply))

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,7 +9,7 @@ macro_rules! define {
 		unsafe impl<'a> Sync for $cookie<'a> { }
 
 		impl<'a> $cookie<'a> {
-			pub fn get_reply(&self) -> Result<$reply, xcb::GenericError> {
+			pub fn get_reply(&self) -> Result<$reply, xcb::ReplyError> {
 				unsafe {
 					if self.0.checked {
 						let mut err: *mut xcb_generic_error_t = ptr::null_mut();
@@ -20,7 +20,7 @@ macro_rules! define {
 							Ok($reply(reply))
 						}
 						else {
-							Err(xcb::GenericError { ptr: err })
+							Err(xcb::ReplyError::GenericError(xcb::GenericError { ptr: err }))
 						}
 					}
 					else {
@@ -43,7 +43,7 @@ macro_rules! define {
 		unsafe impl<'a> Sync for $cookie<'a> { }
 
 		impl<'a> $cookie<'a> {
-			pub fn get_reply(&self) -> Result<$reply, xcb::GenericError> {
+			pub fn get_reply(&self) -> Result<$reply, xcb::ReplyError> {
 				unsafe {
 					if self.0.checked {
 						let mut err: *mut xcb_generic_error_t = ptr::null_mut();
@@ -54,7 +54,7 @@ macro_rules! define {
 							Ok($reply(reply))
 						}
 						else {
-							Err(xcb::GenericError { ptr: err })
+							Err(xcb::ReplyError::GenericError(xcb::GenericError { ptr: err }))
 						}
 					}
 					else {
@@ -81,7 +81,7 @@ macro_rules! define {
 		unsafe impl<'a> Sync for $cookie<'a> { }
 
 		impl<'a> $cookie<'a> {
-			pub fn get_reply(&self) -> Result<$reply, xcb::GenericError> {
+			pub fn get_reply(&self) -> Result<$reply, xcb::ReplyError> {
 				unsafe {
 					if self.checked {
 						let mut err: *mut xcb_generic_error_t = ptr::null_mut();
@@ -92,7 +92,7 @@ macro_rules! define {
 							Ok($reply(reply))
 						}
 						else {
-							Err(xcb::GenericError { ptr: err })
+							Err(xcb::ReplyError::GenericError(xcb::GenericError { ptr: err }))
 						}
 					}
 					else {
@@ -119,7 +119,7 @@ macro_rules! define {
 		unsafe impl<'a> Sync for $cookie<'a> { }
 
 		impl<'a> $cookie<'a> {
-			pub fn get_reply(&self) -> Result<($first, $second), xcb::GenericError> {
+			pub fn get_reply(&self) -> Result<($first, $second), xcb::ReplyError> {
 				unsafe {
 					if self.checked {
 						let mut err: *mut xcb_generic_error_t = ptr::null_mut();
@@ -131,7 +131,7 @@ macro_rules! define {
 							Ok((first, second))
 						}
 						else {
-							Err(xcb::GenericError { ptr: err })
+							Err(xcb::ReplyError::GenericError(xcb::GenericError { ptr: err }))
 						}
 					}
 					else {
@@ -159,7 +159,7 @@ macro_rules! define {
 		unsafe impl<'a> Sync for $cookie<'a> { }
 
 		impl<'a> $cookie<'a> {
-			pub fn get_reply(&self) -> Result<$reply, xcb::GenericError> {
+			pub fn get_reply(&self) -> Result<$reply, xcb::ReplyError> {
 				unsafe {
 					if self.checked {
 						let mut err: *mut xcb_generic_error_t = ptr::null_mut();
@@ -170,7 +170,7 @@ macro_rules! define {
 							Ok(reply)
 						}
 						else {
-							Err(xcb::GenericError { ptr: err })
+							Err(xcb::ReplyError::GenericError(xcb::GenericError { ptr: err }))
 						}
 					}
 					else {
@@ -197,7 +197,7 @@ macro_rules! define {
 		unsafe impl<'a> Sync for $cookie<'a> { }
 
 		impl<'a> $cookie<'a> {
-			pub fn get_reply(&self) -> Result<$reply, xcb::GenericError> {
+			pub fn get_reply(&self) -> Result<$reply, xcb::ReplyError> {
 				unsafe {
 					if self.checked {
 						let mut err: *mut xcb_generic_error_t = ptr::null_mut();
@@ -208,7 +208,7 @@ macro_rules! define {
 							Ok(reply)
 						}
 						else {
-							Err(xcb::GenericError { ptr: err })
+							Err(xcb::ReplyError::GenericError(xcb::GenericError { ptr: err }))
 						}
 					}
 					else {


### PR DESCRIPTION
Update xcb-util to use xcb 0.10 instead of xcb 0.9 and wrap `GenericError` into `ReplyError` as done by the xcb 0.10 crate.