### PR TITLE
fix: renderutil should depend on xcb/render

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ image   = []
 cursor  = []
 keysyms = []
 misc    = ["icccm"]
-render  = []
+render  = ["xcb/render"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This PR addresses #19